### PR TITLE
[#27] 데이터베이스 Master/Slave 구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### 사용 기술 및 개발 환경
 
-- IntelliJ, Spring Boot, Maven, Java, MySQL, MyBatis
+- IntelliJ, Spring Boot, Maven, Java, MySQL, MyBatis, Redis
 
 
 
@@ -29,6 +29,8 @@
   1. 회원가입 / 탈퇴
   2. 로그인 / 로그아웃
   3. 회원정보 수정
+  4. 게시글 작성 / 수정 / 삭제 / 조회 기능
+  5. 피드 조회 기능
 
 
 

--- a/src/main/java/me/liiot/snsserver/annotation/ClientDatabase.java
+++ b/src/main/java/me/liiot/snsserver/annotation/ClientDatabase.java
@@ -1,0 +1,14 @@
+package me.liiot.snsserver.annotation;
+
+import me.liiot.snsserver.util.ClientDatabases;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClientDatabase {
+    String value() default ClientDatabases.MASTER;
+}

--- a/src/main/java/me/liiot/snsserver/aspect/ClientDatabaseAspect.java
+++ b/src/main/java/me/liiot/snsserver/aspect/ClientDatabaseAspect.java
@@ -1,0 +1,26 @@
+package me.liiot.snsserver.aspect;
+
+import me.liiot.snsserver.annotation.ClientDatabase;
+import me.liiot.snsserver.config.tool.ClientDatabaseContext;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Component
+@Aspect
+public class ClientDatabaseAspect {
+
+    @Before("@annotation(me.liiot.snsserver.annotation.ClientDatabase)")
+    public void setClientDatabse(JoinPoint joinPoint) {
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String value = method.getAnnotation(ClientDatabase.class).value();
+
+        ClientDatabaseContext.set(value);
+    }
+}

--- a/src/main/java/me/liiot/snsserver/config/DataSourceConfig.java
+++ b/src/main/java/me/liiot/snsserver/config/DataSourceConfig.java
@@ -1,0 +1,52 @@
+package me.liiot.snsserver.config;
+
+import me.liiot.snsserver.config.tool.RoutingDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+ @PropertySource
+ : 지정한 위치의 프로퍼티 파일을 읽어 스프링 Environment 오브젝트에 저장
+   @Configuration 클래스와 함께 사용
+ */
+@Configuration
+@PropertySource("classpath:/db-secret.properties")
+public class DataSourceConfig {
+
+    @Bean(name = "masterDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.master")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "slaveDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.slave")
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "routingDataSource")
+    public DataSource routingDataSource(@Qualifier(value = "masterDataSource") DataSource masterDataSource,
+                                        @Qualifier(value = "slaveDataSource") DataSource slaveDataSource) {
+
+        AbstractRoutingDataSource routingDataSource = new RoutingDataSource();
+        Map<Object, Object> targetDataSources = new HashMap<>();
+
+        targetDataSources.put("master",masterDataSource);
+        targetDataSources.put("slave", slaveDataSource);
+
+        routingDataSource.setTargetDataSources(targetDataSources);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+
+        return routingDataSource;
+    }
+}

--- a/src/main/java/me/liiot/snsserver/config/MyBatisConfig.java
+++ b/src/main/java/me/liiot/snsserver/config/MyBatisConfig.java
@@ -5,6 +5,7 @@ import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,10 +23,6 @@ import javax.sql.DataSource;
     * basePackages: 매퍼를 검색할 패키지 지정
     * 매퍼 인터페이스 파일이 있는 가장 상위 패키지를 지정하면 지정된 패키지에서 하위 패키지를 모두 검색
 
- @PropertySource
- : 지정한 위치의 프로퍼티 파일을 읽어 스프링 Environment 오브젝트에 저장
-   @Configuration 클래스와 함께 사용
-
  @Autowired
  : 필요한 의존 객체의 타입에 해당하는 빈을 찾아 주입
 
@@ -34,14 +31,13 @@ import javax.sql.DataSource;
  */
 @Configuration
 @MapperScan(basePackages = "me.liiot.snsserver.mapper")
-@PropertySource("classpath:/db-secret.properties")
 public class MyBatisConfig {
 
     @Autowired
     private ApplicationContext applicationContext;
 
     @Bean
-    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+    public SqlSessionFactory sqlSessionFactory(@Qualifier(value = "routingDataSource") DataSource dataSource) throws Exception {
         SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
         sqlSessionFactoryBean.setDataSource(dataSource);
         sqlSessionFactoryBean.setMapperLocations(applicationContext.getResources("classpath:/mapper/**/*.xml"));

--- a/src/main/java/me/liiot/snsserver/config/tool/ClientDatabaseContext.java
+++ b/src/main/java/me/liiot/snsserver/config/tool/ClientDatabaseContext.java
@@ -1,5 +1,6 @@
 package me.liiot.snsserver.config.tool;
 
+import me.liiot.snsserver.util.ClientDatabases;
 import org.springframework.util.Assert;
 
 /*
@@ -14,6 +15,8 @@ public class ClientDatabaseContext {
 
     public static void set(String clientDatabase) {
         Assert.notNull(clientDatabase, "clientDatabase cannot be null");
+        Assert.isTrue(clientDatabase == ClientDatabases.MASTER || clientDatabase == ClientDatabases.SLAVE,
+                      "clientDatabase can be only master or slave");
         CONTEXT.set(clientDatabase);
     }
 

--- a/src/main/java/me/liiot/snsserver/config/tool/ClientDatabaseContext.java
+++ b/src/main/java/me/liiot/snsserver/config/tool/ClientDatabaseContext.java
@@ -1,6 +1,7 @@
 package me.liiot.snsserver.config.tool;
 
 import me.liiot.snsserver.util.ClientDatabases;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.Assert;
 
 /*
@@ -15,7 +16,8 @@ public class ClientDatabaseContext {
 
     public static void set(String clientDatabase) {
         Assert.notNull(clientDatabase, "clientDatabase cannot be null");
-        Assert.isTrue(clientDatabase == ClientDatabases.MASTER || clientDatabase == ClientDatabases.SLAVE,
+        Assert.isTrue(StringUtils.equals(clientDatabase, ClientDatabases.MASTER) ||
+                                StringUtils.equals(clientDatabase, ClientDatabases.SLAVE),
                       "clientDatabase can be only master or slave");
         CONTEXT.set(clientDatabase);
     }

--- a/src/main/java/me/liiot/snsserver/config/tool/ClientDatabaseContext.java
+++ b/src/main/java/me/liiot/snsserver/config/tool/ClientDatabaseContext.java
@@ -1,0 +1,27 @@
+package me.liiot.snsserver.config.tool;
+
+import org.springframework.util.Assert;
+
+/*
+ThreadLocal<T>
+: ThreadLocal 변수 제공.
+- ThreadLocal 변수는 멀티 스레드 환경에서 각 스레드마다 독립적이다. (즉, 각 스레드가 별도의 변수처럼 사용할 수 있다.)
+- 스레드 영역에 변수를 저장하기 때문에, 특정 스레드가 실행하는 모든 코드에서 해당 변수 값을 사용할 수 있음
+- get(), set(), remove()를 통해 값에 대해 접근할 수 있다.
+ */
+public class ClientDatabaseContext {
+    private static ThreadLocal<String> CONTEXT = new ThreadLocal<>();
+
+    public static void set(String clientDatabase) {
+        Assert.notNull(clientDatabase, "clientDatabase cannot be null");
+        CONTEXT.set(clientDatabase);
+    }
+
+    public static String getClientDatabase() {
+        return CONTEXT.get();
+    }
+
+    public static void clear() {
+        CONTEXT.remove();
+    }
+}

--- a/src/main/java/me/liiot/snsserver/config/tool/RoutingDataSource.java
+++ b/src/main/java/me/liiot/snsserver/config/tool/RoutingDataSource.java
@@ -1,0 +1,23 @@
+package me.liiot.snsserver.config.tool;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+/*
+AbstractRoutingDataSource
+: 조회 키를 기반으로 대상 DataSource 중 하나를 getConnection()로 호출하여 라우팅.
+  AbstractRoutingDataSource는 targetDataSources라는 Map 오브젝트를 가지고 있는데
+  여기에는 조회 키-DataSource 쌍들이 담겨져 있다. getConnection()에서 determineCurrentLookupKey()를
+  호출하여 조회 키를 리턴받는다. 해당 키로 targetDataSource에 저장된 DataSource 중
+  라우팅할 DataSource가 결정된다. 조회 키 결정 로직은 보통 스레드 바운드 트랜잭션 컨텍스트로 구현된다.
+ */
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+
+        String name = ClientDatabaseContext.getClientDatabase();
+        ClientDatabaseContext.clear();
+
+        return name;
+    }
+}

--- a/src/main/java/me/liiot/snsserver/mapper/FileMapper.java
+++ b/src/main/java/me/liiot/snsserver/mapper/FileMapper.java
@@ -1,21 +1,29 @@
 package me.liiot.snsserver.mapper;
 
+import me.liiot.snsserver.annotation.ClientDatabase;
 import me.liiot.snsserver.model.post.Image;
 import me.liiot.snsserver.model.post.ImageUploadInfo;
+import me.liiot.snsserver.util.ClientDatabases;
 
 import java.util.List;
 
 public interface FileMapper {
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void insertImage(ImageUploadInfo imageUploadInfo);
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void insertImages(List<ImageUploadInfo> imageUploadInfos);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     boolean isExistImages(int postId);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     List<Image> getImages(int postId);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     List<String> getImagePaths(int postId);
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void deleteImages(int postId);
 }

--- a/src/main/java/me/liiot/snsserver/mapper/PostMapper.java
+++ b/src/main/java/me/liiot/snsserver/mapper/PostMapper.java
@@ -1,24 +1,33 @@
 package me.liiot.snsserver.mapper;
 
+import me.liiot.snsserver.annotation.ClientDatabase;
 import me.liiot.snsserver.model.post.Post;
 import me.liiot.snsserver.model.post.PostUploadInfo;
+import me.liiot.snsserver.util.ClientDatabases;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PostMapper {
 
+    @ClientDatabase(ClientDatabases.MASTER)
     void insertPost(PostUploadInfo postUploadInfo);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     int getLatestPostId(String userId);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     Post getPost(int postId);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     List<Post> getPostsByUserId(String userId);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     boolean isAuthorizedOnPost(@Param("userId") String userId, @Param("postId") int postId);
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void updatePost(@Param("postId") int postId, @Param("content") String content);
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void deletePost(int postId);
 }

--- a/src/main/java/me/liiot/snsserver/mapper/UserMapper.java
+++ b/src/main/java/me/liiot/snsserver/mapper/UserMapper.java
@@ -1,9 +1,11 @@
 package me.liiot.snsserver.mapper;
 
+import me.liiot.snsserver.annotation.ClientDatabase;
 import me.liiot.snsserver.model.user.User;
 import me.liiot.snsserver.model.user.UserIdAndPassword;
 import me.liiot.snsserver.model.user.UserSignUpParam;
 import me.liiot.snsserver.model.user.UserUpdateInfo;
+import me.liiot.snsserver.util.ClientDatabases;
 import org.apache.ibatis.annotations.Mapper;
 
 /*
@@ -13,17 +15,24 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface UserMapper {
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void insertUser(UserSignUpParam userSignUpParam);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     boolean isExistUserId(String userId);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     String getPassword(String userId);
 
+    @ClientDatabase(value = ClientDatabases.SLAVE)
     User getUser(String UserId);
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void updateUser(UserUpdateInfo userUpdateInfo);
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void updateUserPassword(UserIdAndPassword userIdAndPassword);
 
+    @ClientDatabase(value = ClientDatabases.MASTER)
     void deleteUser(String userId);
 }

--- a/src/main/java/me/liiot/snsserver/service/AwsFileService.java
+++ b/src/main/java/me/liiot/snsserver/service/AwsFileService.java
@@ -11,6 +11,7 @@ import me.liiot.snsserver.util.FileUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -21,7 +22,6 @@ import software.amazon.awssdk.services.s3.model.*;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -62,6 +62,7 @@ public class AwsFileService implements FileService {
     }
 
     @Override
+    @Transactional
     public void uploadImage(int postId, FileInfo fileInfo) {
 
         ImageUploadInfo imageUploadInfo =
@@ -71,6 +72,7 @@ public class AwsFileService implements FileService {
     }
 
     @Override
+    @Transactional
     public void uploadImages(int postId, List<FileInfo> fileInfos) {
 
         List<ImageUploadInfo> imageUploadInfos = fileInfos.stream()
@@ -81,12 +83,14 @@ public class AwsFileService implements FileService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean isExistImages(int postId) {
 
         return fileMapper.isExistImages(postId);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Image> getImages(int postId) {
 
         return fileMapper.getImages(postId);
@@ -123,6 +127,7 @@ public class AwsFileService implements FileService {
     }
 
     @Override
+    @Transactional
     public void deleteImages(int postId) {
         List<String> imagePaths = fileMapper.getImagePaths(postId);
 

--- a/src/main/java/me/liiot/snsserver/service/AwsFileService.java
+++ b/src/main/java/me/liiot/snsserver/service/AwsFileService.java
@@ -11,7 +11,6 @@ import me.liiot.snsserver.util.FileUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -62,7 +61,6 @@ public class AwsFileService implements FileService {
     }
 
     @Override
-    @Transactional
     public void uploadImage(int postId, FileInfo fileInfo) {
 
         ImageUploadInfo imageUploadInfo =
@@ -72,7 +70,6 @@ public class AwsFileService implements FileService {
     }
 
     @Override
-    @Transactional
     public void uploadImages(int postId, List<FileInfo> fileInfos) {
 
         List<ImageUploadInfo> imageUploadInfos = fileInfos.stream()
@@ -83,14 +80,12 @@ public class AwsFileService implements FileService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public boolean isExistImages(int postId) {
 
         return fileMapper.isExistImages(postId);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<Image> getImages(int postId) {
 
         return fileMapper.getImages(postId);
@@ -127,7 +122,6 @@ public class AwsFileService implements FileService {
     }
 
     @Override
-    @Transactional
     public void deleteImages(int postId) {
         List<String> imagePaths = fileMapper.getImagePaths(postId);
 

--- a/src/main/java/me/liiot/snsserver/service/LocalFileService.java
+++ b/src/main/java/me/liiot/snsserver/service/LocalFileService.java
@@ -11,7 +11,6 @@ import me.liiot.snsserver.util.FileUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -59,7 +58,6 @@ public class LocalFileService implements FileService {
     }
 
     @Override
-    @Transactional
     public void uploadImage(int postId, FileInfo fileInfo) {
 
         ImageUploadInfo imageUploadInfo =
@@ -69,7 +67,6 @@ public class LocalFileService implements FileService {
     }
 
     @Override
-    @Transactional
     public void uploadImages(int postId, List<FileInfo> fileInfos) {
 
         List<ImageUploadInfo> imageUploadInfos = fileInfos.stream()
@@ -80,14 +77,12 @@ public class LocalFileService implements FileService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public boolean isExistImages(int postId) {
 
         return fileMapper.isExistImages(postId);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<Image> getImages(int postId) {
 
         return fileMapper.getImages(postId);
@@ -117,7 +112,6 @@ public class LocalFileService implements FileService {
     }
 
     @Override
-    @Transactional
     public void deleteImages(int postId) {
         List<String> imagePaths = fileMapper.getImagePaths(postId);
 

--- a/src/main/java/me/liiot/snsserver/service/LocalFileService.java
+++ b/src/main/java/me/liiot/snsserver/service/LocalFileService.java
@@ -11,12 +11,12 @@ import me.liiot.snsserver.util.FileUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -59,6 +59,7 @@ public class LocalFileService implements FileService {
     }
 
     @Override
+    @Transactional
     public void uploadImage(int postId, FileInfo fileInfo) {
 
         ImageUploadInfo imageUploadInfo =
@@ -68,6 +69,7 @@ public class LocalFileService implements FileService {
     }
 
     @Override
+    @Transactional
     public void uploadImages(int postId, List<FileInfo> fileInfos) {
 
         List<ImageUploadInfo> imageUploadInfos = fileInfos.stream()
@@ -78,12 +80,14 @@ public class LocalFileService implements FileService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean isExistImages(int postId) {
 
         return fileMapper.isExistImages(postId);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Image> getImages(int postId) {
 
         return fileMapper.getImages(postId);
@@ -113,6 +117,7 @@ public class LocalFileService implements FileService {
     }
 
     @Override
+    @Transactional
     public void deleteImages(int postId) {
         List<String> imagePaths = fileMapper.getImagePaths(postId);
 

--- a/src/main/java/me/liiot/snsserver/util/ClientDatabases.java
+++ b/src/main/java/me/liiot/snsserver/util/ClientDatabases.java
@@ -1,0 +1,8 @@
+package me.liiot.snsserver.util;
+
+public class ClientDatabases {
+
+    public static final String MASTER = "master";
+
+    public static final String SLAVE = "slave";
+}


### PR DESCRIPTION
- Lookup Key에 따라 DataSource를 결정하는 RoutingDataSource 구현
- ThreadLocal 변수에 Lookup Key 값을 저장하는 ClientDatabaseContext 구현
- 사용자가 지정한 value에 따라 ClientDatabaseContext에 값을 저장하는 ClientDatabaseAspect / ClientDatabase 어노테이션 구현
- 각 Mapper 별로 ClientDatabse 어노테이션을 사용하여 master/slave 분기